### PR TITLE
Use permanent invite instead of vanity URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -38,7 +38,7 @@
   <body>
   <article class="markdown-body">
   <h1>YodaHost</h1>
-	  <p>A decent yet free* image hosting for <span id="examples"></span>. In closed beta. Apply in <a href="https://discord.gg/windows">our Discord server.</a></p>
+	  <p>A decent yet free* image hosting for <span id="examples"></span>. In closed beta. Apply in <a href="https://discord.gg/BNcA9nsV8s" target="_blank">our Discord server.</a></p>
 	  <h3>Stats</h3>
 	  <ul>
 		  <li><b><?php system("du -sh images | grep -o '^\S*'") ?></b> disk space used</li>


### PR DESCRIPTION
Because the boosts on blobby are about to expire soon, we will lose our vanity url, so I replaced the vanity url with a permanent invite to blobby. @aboutDavid 